### PR TITLE
Update Dockerfile to point to new compiler-explorer repository URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "*** Installing Compiler Explorer ***" \
     && apt-get autoremove --purge -y \
     && apt-get autoclean -y \
     && rm -rf /var/cache/apt/* /tmp/* \
-    && git clone https://github.com/mattgodbolt/compiler-explorer.git /compiler-explorer \
+    && git clone https://github.com/compiler-explorer/compiler-explorer.git /compiler-explorer \
     && cd /compiler-explorer \
     && echo "Add missing dependencies" \
     && npm i @sentry/node \


### PR DESCRIPTION
The repository URL for compiler-explorer changed from https://github.com/mattgodbolt/compiler-explorer to https://github.com/compiler-explorer/compiler-explorer. While there is a redirect in place, I want to suggest to move the URL for future-proofing and additional clarity.