### PR TITLE
Add github key, to enable no-interaction clone inside a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,21 @@ RUN echo "*** Installing Compiler Explorer ***" \
         wget \
         ca-certificates \
         nodejs \
+        openssh-client \
         make \
         git \
     && apt-get autoremove --purge -y \
     && apt-get autoclean -y \
-    && rm -rf /var/cache/apt/* /tmp/* \
-    && git clone https://github.com/compiler-explorer/compiler-explorer.git /compiler-explorer \
-    && cd /compiler-explorer \
+    && rm -rf /var/cache/apt/* /tmp/*
+
+# Create known_hosts and add github key, to enable no-interaction clone
+RUN mkdir /root/.ssh \
+    && touch /root/.ssh/known_hosts \
+    && ssh-keyscan github.com >> /root/.ssh/known_hosts
+
+RUN git clone https://github.com/compiler-explorer/compiler-explorer.git /compiler-explorer
+
+RUN cd /compiler-explorer \
     && echo "Add missing dependencies" \
     && npm i @sentry/node \
     && npm run webpack

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ EXPOSE 10240
 RUN echo "*** Installing Compiler Explorer ***" \
     && DEBIAN_FRONTEND=noninteractive apt-get update \
     && apt-get install -y curl \
-    && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+    && curl -sL https://deb.nodesource.com/setup_18.x | bash - \
     && apt-get install -y \
         wget \
         ca-certificates \


### PR DESCRIPTION
I suspect the Dockerfile was created before github depracated git over http - today it's ssh only, so these fixes were necessary for my `docker-compose build` to succeed.
Added some extra layers just to avoid re-installing stuff in case anything goes wrong.

